### PR TITLE
feat: update header

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -38,7 +38,7 @@ export {
 export { Bloom, encodeReceipt } from "https://esm.sh/@ethereumjs/vm@7.1.0";
 export type { TxReceipt } from "https://esm.sh/@ethereumjs/vm@7.1.0";
 
-export type { JsonHeader } from "https://esm.sh/@ethereumjs/block@5.0.1";
+export type { JsonRpcBlock } from "https://esm.sh/@ethereumjs/block@5.0.1";
 
 export { Trie } from "https://esm.sh/@ethereumjs/trie@6.0.1";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,9 @@ export default async function transform({
     receiptRoot: receiptTrie.root(),
     transactionRoot: transactionTrie.root(),
   });
-  store.push({ collection: "headers", data: { header: ethHeader } });
+  store.push({
+    collection: "headers",
+    data: { header: ethHeader },
+  });
   return store;
 }

--- a/src/types/storeItem.ts
+++ b/src/types/storeItem.ts
@@ -3,7 +3,7 @@ import { JsonRpcLog } from "./log.ts";
 import { JsonRpcReceipt } from "./receipt.ts";
 
 // Eth
-import { JsonHeader, JsonRpcTx } from "../deps.ts";
+import { JsonRpcBlock, JsonRpcTx } from "../deps.ts";
 
 type Collection =
   | "transactions"
@@ -16,5 +16,5 @@ export type StoreItem<C = Collection> = {
   data: C extends "transactions" ? { tx: JsonRpcTx }
     : C extends "logs" ? { log: JsonRpcLog }
     : C extends "receipts" ? { receipt: JsonRpcReceipt }
-    : { header: JsonHeader };
+    : { header: JsonRpcBlock };
 };


### PR DESCRIPTION
Updates the header calculation in order to return the JsonRpcBlock type. This type is used instead of the JsonHeader which is more of an internal type to ethereumjs-monorepo and therefore doesn't follow the exact ethereum json rpc specs. 