### PR TITLE
fix null block hash in receipts and logs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 // Utils
-import { padString, toHexString } from "./utils/hex.ts";
+import { NULL_BLOCK_HASH, padString, toHexString } from "./utils/hex.ts";
 
 // Types
 import { toEthTx, toTypedEthTx } from "./types/transaction.ts";
@@ -94,8 +94,6 @@ const isKakarotTransaction = (transaction: Transaction) => {
   }
   return true;
 };
-
-const NULL_BLOCK_HASH = padString("0x", 32);
 
 export default async function transform({
   header,

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -1,5 +1,5 @@
 // Utils
-import { padBigint } from "../utils/hex.ts";
+import { NULL_BLOCK_HASH, padBigint } from "../utils/hex.ts";
 
 // Starknet
 import { Event, hash } from "../deps.ts";
@@ -83,7 +83,7 @@ export function toEthLog({
     logIndex: null,
     transactionIndex: bigIntToHex(BigInt(transaction.transactionIndex ?? 0)),
     transactionHash: transaction.hash,
-    blockHash: isPendingBlock ? null : blockHash,
+    blockHash: isPendingBlock ? NULL_BLOCK_HASH : blockHash,
     blockNumber,
     address,
     data: `0x${paddedData}`,

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -1,5 +1,5 @@
 // Utils
-import { padBytes } from "../utils/hex.ts";
+import { NULL_BLOCK_HASH, padBytes } from "../utils/hex.ts";
 
 // Types
 import { fromJsonRpcLog, JsonRpcLog } from "./log.ts";
@@ -68,7 +68,7 @@ export function toEthReceipt({
   return {
     transactionHash: transaction.hash,
     transactionIndex: bigIntToHex(BigInt(transaction.transactionIndex ?? 0)),
-    blockHash: isPendingBlock ? null : blockHash,
+    blockHash: isPendingBlock ? NULL_BLOCK_HASH : blockHash,
     blockNumber,
     from: transaction.from,
     to: transaction.to,

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -2,6 +2,8 @@
 import { bigIntToHex, bytesToHex } from "../deps.ts";
 import { PrefixedHexString, stripHexPrefix } from "../deps.ts";
 
+export const NULL_BLOCK_HASH = padString("0x", 32);
+
 /**
  * @param hex - A decimal string.
  */
@@ -20,7 +22,7 @@ export function padString(
   hex: PrefixedHexString | undefined,
   length: number,
 ): PrefixedHexString {
-  return "0x" + (stripHexPrefix(hex ?? "0x").padStart(2 * length, "0"));
+  return "0x" + stripHexPrefix(hex ?? "0x").padStart(2 * length, "0");
 }
 
 /**
@@ -31,8 +33,7 @@ export function padBigint(
   b: bigint | undefined,
   length: number,
 ): PrefixedHexString {
-  return "0x" +
-    (stripHexPrefix(bigIntToHex(b ?? 0n)).padStart(2 * length, "0"));
+  return "0x" + stripHexPrefix(bigIntToHex(b ?? 0n)).padStart(2 * length, "0");
 }
 
 /**


### PR DESCRIPTION
We cannot have block hash null for a receipt or a log, they are "mined" in EVM realm. Set sentinel value of blockhash zero hash OR don't index them until they are mined.